### PR TITLE
Update t4t to remove deprecation warning

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,5 +1,5 @@
 #import "@preview/hydra:0.5.2": hydra
-#import "@preview/t4t:0.4.1": get
+#import "@preview/t4t:0.4.2": get
 #import "@preview/headcount:0.1.0": dependent-numbering
 #import "@preview/subpar:0.2.1"
 

--- a/template/setup/macros.typ
+++ b/template/setup/macros.typ
@@ -3,7 +3,7 @@
 
 #import "todo.typ": todo, note-outline // custom todo box
 #import "@preview/subpar:0.2.0" // subfigures
-#import "@preview/t4t:0.4.1": get // utils
+#import "@preview/t4t:0.4.2": get // utils
 #import "@preview/headcount:0.1.0": dependent-numbering
 #import "@preview/glossy:0.5.2": * // acronyms / glossary
 // #import "@preview/codly:1.2.0": * // listings with line numbers

--- a/template/setup/todo.typ
+++ b/template/setup/todo.typ
@@ -2,7 +2,7 @@
 // included as a file here whilst waiting on
 // https://github.com/ntjess/typst-drafting/pull/18
 
-#import "@preview/t4t:0.4.1": get
+#import "@preview/t4t:0.4.2": get
 
 #let note-descent = state("note-descent", (:))
 


### PR DESCRIPTION
This PR updates t4t to version 0.4.2, which removed the last usages of the `type == string` syntax. This removes the depcrecation warning, and prepares the template for Typst 0.14.